### PR TITLE
Fix: Updated Footer Copywrite year

### DIFF
--- a/frontend/src/components/common/Footer.jsx
+++ b/frontend/src/components/common/Footer.jsx
@@ -54,7 +54,7 @@ const Footer = () => {
                     <div className="sub_footer_wrapper">
                         <div className="foot_copyright">
                             <p>
-                                2024 @ <a href="/">TelMedSphere</a> | All Rights Reserved.
+                            {new Date().getFullYear()} @ <a href="/">TelMedSphere</a> | All Rights Reserved.
                             </p>
                         </div>
                         <div className="foot_social">


### PR DESCRIPTION
# Fixes Issue🛠️
Closes #61 


# Description👨‍💻
<!-- Please include a summary of your changes. -->
The footer copyright year has been updated to dynamically reflect the current year using a script. This eliminates the need for manual updates and ensures the footer remains accurate every year.


# Type of Change📄
<!-- Please delete the options that are not relevant to you. -->
Implement a dynamic system for the copyright year that automatically updates to the current year. This can be achieved using a simple script that retrieves the current year from the system.

This update will ensure the footer always displays the correct year without requiring manual intervention, keeping the website accurate and up-to-date.

- [x] Bug fix (non-breaking change which fixes a bug)

# Checklist✅
<!-- Please delete the options that are not relevant to you. -->

- [x] I am an Open Source contributor
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas

# Screenshots/GIF📷
<!-- Please add screenshots or a GIF to demonstrate your changes. -->
Before-
![400430201-d32dbcd1-c650-43ec-9b4e-6127322bbcc3](https://github.com/user-attachments/assets/52f92185-f56f-4c12-89b3-a5af752449ec)
After-
![400430017-42c0e349-a773-4482-b2b6-df8c2eecab31](https://github.com/user-attachments/assets/b83f63d9-0e09-4739-9e51-50e4395709a7)

