### PR TITLE
Updated REAMDE.md to use npm ci instead of npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ TelMedSphere is designed to make healthcare simple and accessible for both docto
  # Navigate to frontend directory
  cd frontend    
  # Install all npm packages for react frontend
- npm install
+ # Use `npm ci` to avoid changing package-lock.json after every install https://stackoverflow.com/a/56254478  
+ npm ci
  # Set .env file
  copy .env.example .env
  # (For linux) cp .env.example .env


### PR DESCRIPTION
# Fixes Issue🛠️
Issues regarding `package-lock.json` conflicts

# Description👨‍💻
Refer: https://stackoverflow.com/a/56254478
> A big downside of `npm install` command is its unexpected behavior that it may mutate the `package-lock.json`, whereas `npm ci` only uses the versions specified in the lockfile and produces an error
>
>    if the `package-lock.json` and `package.json` are out of sync
>    if a `package-lock.json` is missing.
>
>**Hence, running `npm install` locally, esp. in larger teams with multiple developers, may lead to lots of conflicts within the `package-lock.json` and developers to decide to completely delete the `package-lock.json` instead.**

# Screenshots/GIF📷

## Using `npm install`
- Changes contents of `package-lock.json`
![Screenshot_20250131_230140](https://github.com/user-attachments/assets/97fa69b9-95ca-48e1-bf97-0c855c7ae3e9)

## Using `npm ci`
- Does not change `package-lock.json`
![Screenshot_20250131_232007-1](https://github.com/user-attachments/assets/698ff0cf-82cf-4e52-bd57-7d150025c2f7)


# Type of Change📄
<!-- Please delete the options that are not relevant to you. -->

- [x] Documentation (non-breaking change which updates or adds documentation)
