### PR TITLE
Coverted styling of Disease.jsx and implemented logic to store patientInfo in localstorage

### DIFF
--- a/frontend/src/components/diseasePrediction/Disease.jsx
+++ b/frontend/src/components/diseasePrediction/Disease.jsx
@@ -1,176 +1,15 @@
-// import React, { Component } from "react";
-
-// // class Disease extends Component {
-// //   state = {
-// //     patientInfo: this.props.patientInfo,
-// //     disease_with_possibility: this.props.disease_with_possibility,
-// //   };
-// class Disease extends Component {
-//   state = {
-//     patientInfo: [],
-//     disease_with_possibility: [],
-//   };
-
-//   componentDidMount() {
-//     // Ensure patientInfo is set from props on mount
-//     if (this.props.patientInfo) {
-//       this.setState({ patientInfo: this.props.patientInfo });
-//     }
-//   }
-//   componentDidUpdate(prevProps, prevState) {
-//     // Update patientInfo if it changes in props
-//     if (prevProps.patientInfo !== this.props.patientInfo) {
-//       this.setState({ patientInfo: this.props.patientInfo });
-//     }
-
-//     // Trigger fetch only when patientInfo is updated and not empty
-//     if (prevState.patientInfo !== this.state.patientInfo && this.state.patientInfo.length > 0) {
-//       const symptoms = this.state.patientInfo.map((info) => info.answer); // Assuming `answer` contains symptoms
-
-//       fetch("http://127.0.0.1:5000/predict", {
-//         method: "POST",
-//         headers: {
-//           "Content-Type": "application/json",
-//         },
-//         body: JSON.stringify(symptoms),
-//       })
-//         .then((response) => response.json())
-//         .then((data) => {
-//           const updatedDiseases = data.map((item) => ({
-//             name: item.disease,
-//             possibility: (item.probability * 100).toFixed(2), // Convert probability to percentage
-//             disease_symptom: symptoms, // User-provided symptoms
-//             symptom_user_has: symptoms, // Aligning structure
-//             description: item.description, // Disease description
-//             precautions: item.precautions, // Disease precautions
-//           }));
-//           this.setState({ disease_with_possibility: updatedDiseases });
-//         })
-//         .catch((error) => console.error("Error fetching predictions:", error));
-//     }
-//   }
-
-//   get_current_html = () => {
-//     const filtered_list = this.state.disease_with_possibility.filter((e) => {
-//       return e.possibility > 0;
-//     });
-//     filtered_list.sort((a, b) => -a.possibility.localeCompare(b.possibility, undefined, { numeric: true }) || a.name.localeCompare(b.name));
-//     return filtered_list.length !== 0 ? (
-//       <div className="grid-row width-full DiseaseComponent">
-//         <div className="col-12 tablet:grid-col-12 patientInfo">
-//           <h3>Patient gender: {this.props.gender}</h3>
-//           <h3>Patient age: {this.props.age}</h3>
-//         </div>
-//         <div className="col-12 tablet:grid-col-12 patientQuestions">
-//           {this.state.patientInfo.map((key, id) => (
-//             <div className="singleQuestion" key={id}>
-//               <p>{key.question}</p>
-//               <p>{key.answer}</p>
-//             </div>
-//           ))}
-//         </div>
-//         <div className="col-12 tablet:grid-col-12 DiagnosisReport">
-//           <h2>Diagnosis Report</h2>
-//           {filtered_list.map((key, id) => (
-//             <div className="reportDiv" key={id}>
-//               <div className="reportDiv-item">
-//                 <div className="titleReport">
-//                   <h4>{key.name}</h4>
-//                   <a href={`https://en.wikipedia.org/wiki/${key.name}`} title={"wikipedia"} rel="noopener noreferrer" target="blank">
-//                     i
-//                   </a>
-//                 </div>
-//                 <div className="Possibility">
-//                   <p>
-//                     Possibility <span>{key.possibility}%</span>
-//                   </p>
-//                   <div className="possibilityProgressBar">
-//                     <div style={{ width: `${key.possibility}%` }}></div>
-//                   </div>
-//                 </div>
-//               </div>
-//               <div className="diseaseSymptoms">
-//                 {/* <h4>Disease Symptoms</h4>
-//                 <ul>
-//                   {key.disease_symptom.sort().map((item, index) => {
-//                     return key.symptom_user_has.includes(item) ? (
-//                       <li key={index} className="active">
-//                         {item}
-//                       </li>
-//                     ) : (
-//                       <li key={index}>{item}</li>
-//                     );
-//                   })}
-//                 </ul> */}
-//                 <h4>Description</h4>
-//                 <p>{key.description}</p>
-//                 <h4>Precautions</h4>
-//                 <ul>
-//                   {key.precautions.map((precaution, index) => (
-//                     <li key={index}>{precaution}</li>
-//                   ))}
-//                 </ul>
-//               </div>
-//             </div>
-//           ))}
-//         </div>
-//         <div>Always visit a doctor if you have any symptoms of a disease or call your local hospital</div>
-//       </div>
-//     ) : (
-//       <>
-//         <div className="grid-row width-full DiseaseComponent">
-//           <div className="col-12 tablet:grid-col-12 patientInfo">
-//             <h3>Patient gender: {this.props.gender}</h3>
-//             <h3>Patient age: {this.props.age}</h3>
-//           </div>
-//           <p> Cannot determine possible diseases due to lack of symptoms. Please retry the analysis with actual symptoms or call your local hospital if it is an emergency.</p>
-//         </div>
-//       </>
-//     );
-//   };
-
-//   render() {
-//     return <div id="Disease">{this.get_current_html()}</div>;
-//   }
-// }
-
-// export default Disease;
-
 import React, { Component } from "react";
 
 class Disease extends Component {
   state = {
     gender: this.props.gender,
     age: this.props.age,
-    patientInfo: this.props.patient_question || [], // Initialize patientInfo as an empty array
+    patientInfo:
+      JSON.parse(localStorage.getItem("patient_question") || "[]") ||
+      this.props.patient_question ||
+      [], // Initialize patientInfo as an empty array
     disease_possibility: this.props.disease_possibility || [], // To store the diseases with possibilities
   };
-
-  // componentDidMount() {
-  //   // Ensure patientInfo is set from props on mount
-  //   if (this.props.patientInfo) {
-  //     this.setState({ patientInfo: this.props.patientInfo });
-  //   }
-  // }
-  // componentDidUpdate(prevProps) {
-  //   // Update state when the result prop changes
-  //   // if (this.props.result !== prevProps.result) {
-  //   //   this.setState({ disease_with_possibility: this.props.result });
-  //   // }
-  // }
-  // componentDidUpdate(prevProps) {
-  //   if (
-  //     this.props.result !== prevProps.result &&
-  //     Array.isArray(this.props.result)
-  //   ) {
-  //     this.setState({ disease_possibility: this.props.result }, () => {
-  //       console.log(
-  //         "✅ Updated disease_with_possibility:",
-  //         this.state.disease_possibility
-  //       );
-  //     });
-  //   }
-  // }
 
   get_current_html = () => {
     const filtered_list = this.state.disease_possibility.filter(
@@ -182,15 +21,21 @@ class Disease extends Component {
     );
 
     return filtered_list.length !== 0 ? (
-      <div className="grid-row width-full DiseaseComponent">
-        <div className="col-12 tablet:grid-col-12 patientInfo">
+      <div className="text-blue-7 py-2 px-4 leading-[1.7]">
+        <div className="text-blue-9 py-4 px-0">
           <h3>Patient gender: {this.state.gender}</h3>
           <h3>Patient age: {this.state.age}</h3>
         </div>
-        <div className="col-12 tablet:grid-col-12 patientQuestions">
+        <h2 className="text-blue-7">Patient Information</h2>
+        <div className="px-0 py-2 border-t-[2px] border-blue-9">
           {this.state.patientInfo.length > 0 ? (
             this.state.patientInfo.map((key, id) => (
-              <div className="singleQuestion" key={id}>
+              <div
+                className={`px-0 py-2 ${
+                  id > 0 && "border-top-[1px] border-blue-9"
+                }`}
+                key={id}
+              >
                 <p>{key.question}</p>
                 <p>{key.answer}</p>
               </div>
@@ -199,36 +44,51 @@ class Disease extends Component {
             <p>No patient information available.</p>
           )}
         </div>
-        <div className="col-12 tablet:grid-col-12 DiagnosisReport">
+        <div className="py-4 px-0 text-blue-7">
           <h2>Diagnosis Report</h2>
           {filtered_list.map((key, id) => (
-            <div className="reportDiv" key={id}>
-              <div className="reportDiv-item">
-                <div className="titleReport">
-                  <h4>{key.disease}</h4>
+            <div
+              className="px-0 py-2 border-t-[2px] border-blue-9 text-blue-7"
+              key={id}
+            >
+              <div className="flex justify-between items-center flex-wrap py-4 px-0">
+                <div className="flex justify-between items-center flex-wrap">
+                  <h4 className="text-[1.2rem]">{key.disease}</h4>
                   <a
                     href={`https://en.wikipedia.org/wiki/${key.name}`}
                     title={"wikipedia"}
                     rel="noopener noreferrer"
                     target="_blank"
+                    className="bg-blue-9 text-white-1 leading-[1.5rem] py-0 px-[0.6rem] rounded-[2rem] ml-4 text-no no-underline focus:outline-none"
                   ></a>
                 </div>
-                <div className="Possibility">
+                <div className="flex justify-between items-center flex-wrap">
                   <p>
-                    Probability <span>{key.probability * 100}%</span>
+                    Probability{" "}
+                    <span className="text-blue-9 font-semibold">
+                      {key.probability * 100}%
+                    </span>
                   </p>
-                  <div className="possibilityProgressBar">
-                    <div style={{ width: `${key.probability * 100}%` }}></div>
+                  <div className="bg-[#ccc] w-full h-[4px] ml-2 rounded-[1rem]">
+                    <div
+                      style={{ width: `${key.probability * 100}%` }}
+                      className="h-full bg-blue-9"
+                    ></div>
                   </div>
                 </div>
               </div>
-              <div className="diseaseSymptoms">
-                <h4>Description</h4>
+              <div className="border-t-[1px] border-white-1">
+                <h4 className="mt-4">Description</h4>
                 <p>{key.description}</p>
-                <h4>Precautions</h4>
-                <ul>
+                <h4 className="mt-5">Precautions</h4>
+                <ul className="list-none">
                   {key.precautions.map((precaution, index) => (
-                    <li key={index}>{precaution}</li>
+                    <li
+                      key={index}
+                      className="py-[0.2rem] px-[0.2rem] rounded-[0.5rem]"
+                    >
+                      🔹{precaution}
+                    </li>
                   ))}
                 </ul>
               </div>
@@ -241,8 +101,8 @@ class Disease extends Component {
         </div>
       </div>
     ) : (
-      <div className="grid-row width-full DiseaseComponent">
-        <div className="col-12 tablet:grid-col-12 patientInfo">
+      <div className="text-blue-7 py-2 px-4 leading-[1.7]">
+        <div className="text-blue-9 py-4 px-0">
           <h3>Patient gender: {this.props.gender}</h3>
           <h3>Patient age: {this.props.age}</h3>
         </div>

--- a/frontend/src/pages/DiseasePrediction.jsx
+++ b/frontend/src/pages/DiseasePrediction.jsx
@@ -1,10 +1,7 @@
 import React, {
-  createRef,
   Component,
   useContext,
   useEffect,
-  useState,
-  useRef,
 } from "react";
 import Home from "../components/diseasePrediction/Home";
 // import Patient from "../components/diseasePrediction/Patient1";
@@ -30,14 +27,13 @@ class DP extends Component {
       gender: localStorage.getItem("gender")
         ? localStorage.getItem("gender").toUpperCase()
         : "Male", //Default gender
-      // male: true, // patient checkbox
-      // female: false, // patient checkbox
       home_nav_icon: <p>1</p>,
       patient_nav_icon: <p>2</p>,
       symptom_nav_icon: <p>3</p>,
       disease_nav_icon: <p>4</p>,
-      patient_question: [],
-      // patient_2_next_button_disabled: "",
+      patient_question: localStorage.getItem("patient_question")
+        ? localStorage.getItem("patient_question")
+        : [],
       home_nav_value: false,
       patient_nav_value: false,
       symptom_nav_value: false,
@@ -78,6 +74,9 @@ class DP extends Component {
           button_is_disabled: true,
           user_symptom_length: 0,
           home_button_checked: true,
+          patient_question: localStorage.getItem("patient_question")
+            ? JSON.parse(localStorage.getItem("patient_question")) // Convert back to array
+            : [],
         });
       case "Symptom":
         // Call the Symptom component's sendSymptomsToBackend method
@@ -92,6 +91,9 @@ class DP extends Component {
           disease_nav_value: true,
           button_is_disabled: true,
           home_button_checked: true,
+          patient_question: localStorage.getItem("patient_question")
+            ? JSON.parse(localStorage.getItem("patient_question")) 
+            : [],
         });
       case "Disease":
         return this.setState({
@@ -108,7 +110,6 @@ class DP extends Component {
           patient_nav_icon: <p>2</p>,
           symptom_nav_icon: <p>3</p>,
           disease_nav_icon: <p>4</p>,
-          patient_question: [],
           home_nav_value: false,
           patient_nav_value: false,
           symptom_nav_value: false,
@@ -121,7 +122,6 @@ class DP extends Component {
   };
 
   get_gender = (e) => {
-    // console.log("slf", e.target.value);
     if (e.target.value === "male") {
       this.setState({
         male: true,
@@ -150,7 +150,7 @@ class DP extends Component {
   //   }));
   // };
 
-  patient_2_callback = (data) => {
+  patient_2_callback = async (data) => {
     let d = data.filter((key) => {
       return key.answer !== "";
     });
@@ -160,6 +160,7 @@ class DP extends Component {
       button_is_disabled: avl,
       symptom_nav_value: true,
     });
+    localStorage.setItem("patient_question", JSON.stringify(data));
   };
 
   updateSymptoms = (user_symptoms) => {
@@ -210,6 +211,7 @@ class DP extends Component {
           user_symptom_length: 0,
           button_is_disabled: false,
           home_button_checked: true,
+          patient_question: this.state.patient_question,
         });
       case "Symptom":
         return this.setState({
@@ -276,7 +278,7 @@ class DP extends Component {
             pageCallback={this.symptom_page_button_callback}
             setResult={(result) => this.setState({ result })}
             updateDiseasePossibility={this.updateDiseasePossibility}
-            updateSymptoms={this.updateSymptoms} // Callback to update symptoms in main state
+            updateSymptoms={this.updateSymptoms} 
           />
         );
       case "Disease":
@@ -294,7 +296,7 @@ class DP extends Component {
               if (el) {
                 setTimeout(() => {
                   if (el) el.innerText = "Error predicting disease.";
-                }, 5000);
+                }, 10000);
               }
             }}
           >
@@ -427,7 +429,6 @@ class DP extends Component {
               >
                 Back
               </button>
-              {/* {current_page === "Symptom" ? this.renderResetButton() : ""} */}
               <button
                 className={`bg-blue-3 border-[1px] border-blue-5 text-white-1 py-[10px] px-[12px] rounded-[5px] mb-[8px] mx-[20px] font-sans transition-all duration-300 ease-in-out hover:bg-blue-5 active:bg-blue-5 disabled:bg-blue-5 disabled:cursor-not-allowed`}
                 disabled={!home_button_checked || button_is_disabled}


### PR DESCRIPTION
…

# Fixes Issue🛠️
<!-- Example: Closes #32 -->

Closes #287 

# Description👨‍💻
<!-- Please include a summary of your changes. -->


-  **Converted styling from scss to tailwind:** Refactored the entire `Disease.jsx` styling to align with the project's design standards, ensuring a more polished and cohesive UI experience.  
-  **Persistent `patientInfo` Storage:**  
  - Implemented a structured approach to store `patientInfo` in `localStorage` using `JSON.stringify()`.  
  - Ensured seamless retrieval via `JSON.parse()`, resolving the previous issue where `Disease.jsx` couldn't access the patient's selected responses.  
  - This guarantees data persistence across page reloads and navigation, improving overall user experience.  


### **Changes Made**  
✔ Fully restructured `Disease.jsx` styling for UI consistency.  
✔ Implemented robust localStorage handling for `patientInfo`, ensuring accessibility across components.  
✔ Fixed an issue where patient responses were not retained in `Disease.jsx`.  
✔ Improved state management to prevent potential data loss on navigation.  





# Type of Change📄
<!-- Please delete the options that are not relevant to you. -->

- [ ] Bug fix (non-breaking change which fixes a bug)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Style (non-breaking change which improves website style or formatting)
- [ ] Responsiveness (non-breaking change which improves UI/UX on different screen sizes)

# Checklist✅
<!-- Please delete the options that are not relevant to you. -->

- [ ] I am an Open Source contributor
- [ ] I have performed a self-review of my code
- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas



# Screenshots/GIF📷
<!-- Please add screenshots or a GIF to demonstrate your changes. -->

https://github.com/user-attachments/assets/235c34b0-bbba-4e4b-b0d0-ca4ab6961dd5
